### PR TITLE
`RemoteHandle` requires feature flag 'channel'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ version = "^0.3"
 version = "^0.3"
 
 [dependencies.futures-util]
+features = ["channel"]
 version = "^0.3"
 
 [dependencies.pin-utils]

--- a/Cargo.yml
+++ b/Cargo.yml
@@ -108,7 +108,7 @@ dependencies:
   # Public deps
   #
   futures-task        : { version: ^0.3                                         }
-  futures-util        : { version: ^0.3                                         }
+  futures-util        : { version: ^0.3, features: [ channel ]                  }
   futures-executor    : { version: ^0.3, optional: true                         }
   tracing-futures     : { version: ^0.2, optional: true, features: [futures-03] }
 

--- a/src/join_handle.rs
+++ b/src/join_handle.rs
@@ -1,4 +1,4 @@
-#[ allow(unused_imports) ]
+#[ allow(unused_imports) ] // some imports are conditional on features
 //
 use
 {


### PR DESCRIPTION
In my project I've found that using `no-default-features` along with `notwasm` and `tokio_ct` does not enable the `channel` feature flag for `futures_util`.

RemoteHandle requires `channel`.